### PR TITLE
Remove previous screenshot image

### DIFF
--- a/src/scanner/AutoBarcodeScanner.cpp
+++ b/src/scanner/AutoBarcodeScanner.cpp
@@ -231,6 +231,9 @@ void AutoBarcodeScanner::processDecode() {
         m_scanProcessMutex.unlock();
 
         if (scanActive) {
+            if (QFileInfo::exists(m_decoder->getCaptureLocation()))
+                QFile::remove(m_decoder->getCaptureLocation());
+
             QDBusMessage m = QDBusMessage::createMethodCall("org.nemomobile.lipstick", "/org/nemomobile/lipstick/screenshot", "org.nemomobile.lipstick", "saveScreenshot");
             m << m_decoder->getCaptureLocation();
             QDBusMessage reply = QDBusConnection::sessionBus().call(m);


### PR DESCRIPTION
the dbus call "saveScreenshot" does not overwrite an existing captured image, we need to remove it before capturing the next screenshot.
